### PR TITLE
[misc] Update GHA workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
     tags:
       - "/^v\\d+\\.\\d+\\.\\d+(-(alpha|beta|rc)(\\.\\d+)?)?$/"
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 0 * * 6"
 
 jobs:
   unit-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,6 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2.1.0
       with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           file: ./coverage.xml
 


### PR DESCRIPTION
Run scheduled tests only on Saturdays and don't fail if Codecov fails an upload