### PR TITLE
[misc] Drop support for Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ without being overwhelmed by details of the internals.
 ## Requirements
 PyGitViz requires the following to run.
 
-* Python 3.6 or higher
+* Python 3.7 or higher
 * A PDF viewer
     - The viewer should ideally refresh automatically when a PDF is updated, as
       PyGitViz will render a new PDF for each change it detects in the

--- a/setup.py
+++ b/setup.py
@@ -41,13 +41,15 @@ setup(
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX",
         "Operating System :: MacOS",
         "Operating System :: Microsoft :: Windows :: Windows 10",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Python 3.6 has reached end of life, so no reason to support it anymore.