### PR TITLE
[fix] Fix crash on removing git directory when pygitviz is running

### DIFF
--- a/src/_pygitviz/git.py
+++ b/src/_pygitviz/git.py
@@ -119,6 +119,9 @@ def collect_refs(git_root: pathlib.Path) -> List[Ref]:
     """Return concrete refs, remote refs and the HEAD symbolic ref. Return
     nothing if there are no concrete or remote refs.
     """
+    if not git_root.is_dir():
+        return []
+
     refs = [
         ref
         for ref in itertools.chain(

--- a/tests/graphviz_test.py
+++ b/tests/graphviz_test.py
@@ -35,3 +35,10 @@ def test_git_to_dot_creates_expected_dotfile(repo_test_case, tmp_path):
     actual_graph = graphviz.git_to_dot(git_dir)
 
     assert actual_graph.strip() == expected_graph.strip()
+
+def test_git_to_dot_produces_empty_graph_for_non_existing_git_dir(tmp_path):
+    non_existing_dir = tmp_path / ".git"
+
+    graph = graphviz.git_to_dot(non_existing_dir)
+
+    assert graph == 'digraph G {}'


### PR DESCRIPTION
It crashed on collecting refs when the git root was removed, which is inconvenient as if you need to "restart" a presentation you sometimes want to just have a clean slate, without restarting pygitviz.